### PR TITLE
Every day something is dropped.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,13 @@ cargo test --all-targets
 src/
   water/          # Core types: Vapor, Rain, Stream, River, Ocean
   watershed/      # Spring trait, VolumeSensor, spring implementations
+    source/       # LlmSource trait, ClaudeCliSource, AnthropicSource
+  vessel/         # tmux session management (the window, not the mountain)
   confluence/     # Eddy detection, yielding, stream merging
   still_lake/     # Final refinement (the five questions)
   creation/       # Book, podcast, software creation flows
   config/         # Configuration loading
+  flow.rs         # TaoFlow — the complete Rain to Ocean journey
   error.rs        # FlowError hierarchy
 ```
 
@@ -49,3 +52,13 @@ See `docs/implementation.md` "Skills: Teaching the Builder" for details.
 - Water types are distinct. Stream cannot become Ocean without passing through River.
 - Silence is valid. A dry spring (returning None) is wisdom, not failure.
 - Build like water. When blocked, flow around. When in a valley, fill it and become a lake.
+
+## The Lesson of Enough
+
+*"In the practice of the Tao, every day something is dropped."* — Chapter 48
+
+- **Do not add fields, types, or dependencies before they carry water.** Each should arrive with the phase that gives it meaning. An unused field is a vessel shaped before the water comes — it may be the wrong shape.
+- **Do not explain in comments what the code already says.** If the code is clear, the comment is noise. If the code is unclear, fix the code. The strongest code teaches without words.
+- **Do not quote the Tao Te Ching to justify a design decision.** If the design is sound, it needs no justification. If it is unsound, no quote will save it. The code should *embody* the Tao, not *talk about* it.
+- **The implementation doc (`docs/implementation.md`) is a vision, not the truth.** The source code is the truth. When they diverge, update the doc or accept the divergence — but never mistake the map for the territory.
+- **Know when to stop.** Three similar lines of code are better than a premature abstraction. A simple function is better than a clever one. Enough is enough.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,9 @@ tokio = { version = "1", features = ["full"] }
 async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_yaml = "0.9"
-reqwest = { version = "0.12", features = ["json", "stream"] }
-tracing = "0.1"
-tracing-subscriber = "0.3"
+reqwest = { version = "0.12", features = ["json"] }
 thiserror = "2"
 futures = "0.3"
 
 [dev-dependencies]
-proptest = "1"
 tokio-test = "0.4"

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -7,11 +7,7 @@
 
 ## The Uncarved Block
 
-This document translates the philosophy into practical implementation. But remember:
-
-*"The Tao that can be told is not the eternal Tao."*
-
-The implementation is not the system. The system is the emptiness that the implementation creates. Do not mistake the code for the Tao.
+This document is a vision — the shape the water may take. The code is the water. Where they diverge, trust the code. Code examples below are illustrative, not literal; the source of truth lives in `src/`.
 
 ---
 

--- a/docs/phase_2_reflections.md
+++ b/docs/phase_2_reflections.md
@@ -1,0 +1,71 @@
+# Phase 2 Reflections
+
+## Where the water flows true
+
+The **water cycle metaphor is genuinely strong**. Rain → Stream → River → Ocean is not decoration — the compiler enforces it. You cannot deliver a Stream to the user. It must become an Ocean. The type system *is* the riverbed. This is Chapter 11 made real: "We work with being, but non-being is what we use." The types are being; the constraints between them are non-being — and the constraints are what make the system work.
+
+The **watershed's wu wei** is honest. `receive_rain` doesn't decide which spring should answer. It senses the volume, activates springs by shape, and lets them all flow simultaneously. The code does nothing unnecessary. `simple_merge` picks the deepest stream and says plainly: "Phase 2 — we do the minimum." Chapter 48: *"When nothing is done, nothing is left undone."*
+
+The **mountain and desert springs** are apt. Cold, deep, slow vs. light, quick, sparse. The system prompts match. The relevance threshold ("Silence is wisdom") is genuinely Taoist — a spring that has nothing to contribute returns `None`. Not an error. Not empty output. *Nothing*. Chapter 43: *"That which has no substance enters where there is no space."*
+
+---
+
+## Where the metaphor strains
+
+**1. `LlmSource` — the spring separated from its source**
+
+In nature, a spring *is* its source. You don't separate the mountain from the water that emerges from it. The mountain spring is where deep water becomes visible — they are one thing. But in the code, `MountainSpring` holds a `Box<dyn LlmSource>` — the spring is separated from its underground source through dependency injection.
+
+This separation exists for a real engineering reason (testing, flexibility). But calling it "Source" and "Spring" as separate things creates a duality that the Tao questions. Chapter 1: *"Mystery and manifestations arise from the same source."* The spring and its source are not two things.
+
+Perhaps `LlmSource` tries too hard to name what needs no name. It is the underground — the hidden mechanism. Chapter 56: *"Those who know don't talk."* The trait does its work. Whether we call it Source or Provider or nothing at all — the water flows the same.
+
+**2. `ProviderError` still lives in `error.rs`**
+
+We renamed everything to Source, but the error variant still says `ProviderError`. A small thing, but it reveals: the renaming was surface. The old name persists where we forgot to look. Chapter 1: *"The name that can be named is not the eternal Name."* We were so concerned with correct naming that we missed the inconsistency.
+
+**3. The implementation doc and the source code have diverged**
+
+The doc shows `JoinSet` for concurrent dispatch — the code uses `futures::future::join_all`. The doc shows `SpringBase` — the code has `SpringConfig`. The doc shows an async `VolumeSensor::sense` — the code's is sync. The doc shows `SpringError` — the code has `FlowError`. The doc references `axum` for WebSocket/SSE — `axum` isn't even in `Cargo.toml`. The doc shows `edition = "2024"` — the actual is `2021`.
+
+The implementation document has become a map that doesn't match the territory. Chapter 1 warns us: *"The Tao that can be told is not the eternal Tao."* The doc *told* a version of the system. The code *is* the system. They should not be confused, but nor should they contradict each other.
+
+**4. Over-specification — fields that carry no water**
+
+`Stream` has `flow_rate`, `clarity`, `depth`, `temperature`. `Rain` has `temperature`, `minerals`. `Ocean` has `depth`, `warmth`. Most of these are initialized to defaults and never meaningfully used. They are vessels shaped before the water arrives.
+
+Chapter 48: *"In the practice of the Tao, every day something is dropped."* These fields anticipate future phases. But the Tao says to add when needed, not before. Chapter 63: *"Accomplish the great task by a series of small acts."* Each field should arrive with the phase that gives it meaning.
+
+**5. The vessel sits on shore**
+
+`TmuxVessel` exists but nothing uses it. No spring rides in it. No flow passes through it. It is a boat built and set aside. This isn't wrong — it's Phase 2, and the vessel awaits its passengers. But it is worth seeing clearly: it is unconnected.
+
+**6. Dependencies that flow nowhere**
+
+`serde_yaml`, `tracing`, `tracing-subscriber`, `proptest`, `reqwest` with `stream` feature — all declared, none used in the actual running code. Chapter 48 again. The `Cargo.toml` carries weight the system hasn't earned yet.
+
+---
+
+## The deeper question
+
+The metaphors are mostly apt. The water cycle works. The watershed works. The springs work. The eddy concept is hydrologically sound.
+
+But there's a pattern I notice: the system *talks about* the Tao more than it *embodies* it. The doc comments quote the Tao Te Ching extensively. The variable names are poetic. The module documentation is rich with philosophy. But the Tao says: *"Teaching without words, performing without actions: that is the Master's way."* (Chapter 43)
+
+The strongest alignment is where the code *is* Taoist without saying so — `simple_merge` doing the minimum, `respond` returning `None` for silence, the type system enforcing the water's journey without runtime checks. These are wu wei. They don't need a quote to justify them.
+
+The weakest alignment is where a comment explains *why* something is Taoist. The explanation is the departure. Chapter 5: *"The more you talk of it, the less you understand."*
+
+---
+
+## What was done
+
+These are observations, not directives. The water will find its own course.
+
+1. **Reconcile the implementation doc with the actual code** — or accept that the doc is a vision and the code is the reality, and label them accordingly. A map that contradicts the territory misleads the traveler.
+
+2. **Rename `ProviderError`** — a small fix that completes what was started.
+
+3. **Consider whether unused fields and dependencies should wait** — let each phase bring what it needs. The uncarved block (Chapter 28) is more useful than premature utensils.
+
+4. **Let the code speak** — where a Tao Te Ching quote restates what the code already says, the quote may not be needed. The strongest code teaches without words.

--- a/src/confluence/eddy.rs
+++ b/src/confluence/eddy.rs
@@ -1,47 +1,28 @@
 use serde::{Deserialize, Serialize};
 
-/// The nature of an eddy -- how streams disagree.
-///
-/// Different natures resolve differently, the way different
-/// kinds of turbulence settle in different ways.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum EddyNature {
-    /// One stream is right, one is wrong. Can be verified.
     Factual,
-    /// Both streams may be valid. Richness, not conflict.
     Interpretive,
-    /// Different tone or voice. Diversity, not disagreement.
     Stylistic,
-    /// Different organization of the same truth.
     Structural,
 }
 
-/// A position within an eddy -- one stream's view.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Position {
-    /// Which spring holds this view
     pub source: String,
-    /// The view itself
     pub view: String,
 }
 
 /// A point of divergence between streams.
-///
-/// When two rivers meet at an angle, turbulence is natural.
-/// The turbulence is not wrong. It is the process by which
-/// two waters become one.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Eddy {
-    /// What the disagreement is about
     pub topic: String,
-    /// The different positions held by streams
     pub positions: Vec<Position>,
-    /// The nature of the divergence
     pub nature: EddyNature,
 }
 
 impl Eddy {
-    /// Create a new eddy from two diverging streams.
     pub fn new(topic: impl Into<String>, nature: EddyNature, positions: Vec<Position>) -> Self {
         Self {
             topic: topic.into(),
@@ -50,12 +31,10 @@ impl Eddy {
         }
     }
 
-    /// How many streams are involved in this eddy?
     pub fn stream_count(&self) -> usize {
         self.positions.len()
     }
 
-    /// Is this a factual disagreement that can be verified?
     pub fn is_verifiable(&self) -> bool {
         self.nature == EddyNature::Factual
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,5 @@
 use thiserror::Error;
 
-/// Errors that arise as eddies in the flow.
-///
-/// "Failure is an opportunity." -- Tao Te Ching, Chapter 79
 #[derive(Error, Debug)]
 pub enum FlowError {
     #[error("Spring '{name}' failed to respond: {reason}")]
@@ -17,8 +14,8 @@ pub enum FlowError {
     #[error("Still Lake failed to clarify: {0}")]
     ClarityFailure(String),
 
-    #[error("LLM provider error: {0}")]
-    ProviderError(#[from] reqwest::Error),
+    #[error("Source error: {0}")]
+    SourceError(#[from] reqwest::Error),
 
     #[error("Configuration error: {0}")]
     ConfigError(String),

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -2,11 +2,6 @@ use crate::error::FlowError;
 use crate::water::{Message, Ocean, Rain, River, Role, Stream, Vapor};
 use crate::watershed::Watershed;
 
-/// The complete system. Rain to Ocean.
-///
-/// "The Tao gives birth to One. One gives birth to Two.
-///  Two gives birth to Three.
-///  Three gives birth to ten thousand things." -- Chapter 42
 pub struct TaoFlow {
     watershed: Watershed,
     vapor: Vapor,
@@ -20,41 +15,22 @@ impl TaoFlow {
         }
     }
 
-    /// The complete journey from rain to ocean.
-    ///
-    /// Phase 2: Two springs, simple merge. The Confluence Pool
-    /// and Still Lake will deepen this flow in later phases.
     pub async fn flow(&mut self, user_input: &str) -> Result<String, FlowError> {
-        // Rain falls
         let mut rain = Rain::new(user_input, self.vapor.clone());
-
-        // Springs respond
         let streams = self.watershed.receive_rain(&mut rain).await;
 
         if streams.is_empty() {
             return Err(FlowError::Drought);
         }
 
-        // Simple merge (Phase 2) -- select the deepest stream.
-        // The full Confluence Pool comes in Phase 3.
         let river = Self::simple_merge(streams);
-
-        // Simple pass-through (Phase 2) -- the Still Lake comes in Phase 5.
         let ocean = Ocean::new(river.content);
-
-        // Update vapor for next cycle (the water cycle)
         self.update_vapor(&rain, &ocean);
 
         Ok(ocean.content)
     }
 
-    /// Simple merge: when few streams flow, the deepest carries the river.
-    ///
-    /// "When nothing is done, nothing is left undone." -- Chapter 48
-    ///
-    /// In Phase 2, we do the minimum: pick the stream with the
-    /// greatest depth. The full Confluence (Phase 3) will weave
-    /// multiple streams into a richer river.
+    /// Pick the deepest stream. Full confluence comes later.
     fn simple_merge(streams: Vec<Stream>) -> River {
         debug_assert!(!streams.is_empty());
 
@@ -79,7 +55,6 @@ impl TaoFlow {
         }
     }
 
-    /// The water cycle -- output becomes context for next input.
     fn update_vapor(&mut self, rain: &Rain, ocean: &Ocean) {
         self.vapor.conversation_history.push(Message {
             role: Role::User,
@@ -91,7 +66,6 @@ impl TaoFlow {
         });
     }
 
-    /// Access the current vapor (for testing).
     pub fn vapor(&self) -> &Vapor {
         &self.vapor
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,3 @@
-//! # Tao Flow
-//!
-//! A multi-LLM system that flows like water.
-//!
-//! *"The supreme good is like water, which nourishes all things without trying to."*
-//! -- Tao Te Ching, Chapter 8
-
 pub mod config;
 pub mod confluence;
 pub mod creation;
@@ -25,8 +18,6 @@ mod tests {
     use water::rain::Volume;
     use water::{Message, Role};
 
-    /// The complete journey: Rain -> Stream -> River -> Ocean.
-    /// Each type is distinct. The compiler enforces the path.
     #[test]
     fn water_types_are_distinct() {
         let vapor = Vapor::default();
@@ -35,23 +26,18 @@ mod tests {
         let river = River::from_single(stream.source.clone(), stream.content.clone());
         let ocean = Ocean::new(river.content.clone());
 
-        // Each type carries its identity
         assert_eq!(rain.raw_input, "What is the Tao?");
         assert_eq!(stream.source, "mountain");
         assert_eq!(river.tributary_count(), 1);
         assert!(ocean.has_substance());
     }
 
-    /// The water cycle: ocean becomes vapor for the next rain.
     #[test]
     fn water_cycle_completes() {
         let mut vapor = Vapor::default();
-
-        // First cycle
         let rain = Rain::new("Hello", vapor.clone());
         let ocean = Ocean::new("Greetings, traveler.");
 
-        // Ocean evaporates into vapor
         vapor.conversation_history.push(Message {
             role: Role::User,
             content: rain.raw_input.clone(),
@@ -61,13 +47,11 @@ mod tests {
             content: ocean.content.clone(),
         });
 
-        // Second cycle carries the vapor from the first
         let rain2 = Rain::new("What did I just say?", vapor);
         assert_eq!(rain2.vapor.conversation_history.len(), 2);
         assert_eq!(rain2.vapor.conversation_history[0].content, "Hello");
     }
 
-    /// Volume determines the depth of the watershed's response.
     #[test]
     fn volume_determines_depth() {
         let sensor = watershed::VolumeSensor::new();

--- a/src/vessel/mod.rs
+++ b/src/vessel/mod.rs
@@ -1,21 +1,7 @@
-//! The vessel is not the water. It is the boat you ride,
-//! the window through which you see the mountain.
+//! Persistent session management.
 //!
-//! tmux provides the walls of the space each agent occupies.
-//! Each window allows the user to perceive the agent --
-//! much like you can see the mountain outside of a window,
-//! but the window is not the mountain.
-//!
-//! "Thirty spokes share the wheel's hub;
-//!  It is the center hole that makes it useful.
-//!  Shape clay into a vessel;
-//!  It is the space within that makes it useful."
-//!  -- Tao Te Ching, Chapter 11
-//!
-//! The vessel manages persistent tmux sessions where Claude
-//! processes live. Springs ride in vessels. The vessel carries
-//! the conversation naturally -- the spring does not need to
-//! carry its own memory.
+//! The vessel is not the water — it is the window through
+//! which you see the mountain. Springs ride in vessels.
 
 pub mod tmux;
 

--- a/src/vessel/tmux.rs
+++ b/src/vessel/tmux.rs
@@ -2,24 +2,7 @@ use tokio::process::Command;
 
 use crate::error::FlowError;
 
-/// A tmux vessel -- the walls that hold the space an agent occupies.
-///
-/// The vessel is not the spring. It is the window through which
-/// you perceive the mountain. Each tmux window holds a persistent
-/// Claude process, and the conversation flows naturally within
-/// those walls without the system carrying the water's memory.
-///
-/// tmux session layout:
-/// ```text
-/// tao-flow (session)
-///   mountain (window) — claude, persistent, deep reasoning
-///   desert   (window) — claude, persistent, quick responses
-///   forest   (window) — claude, persistent, creative synthesis
-/// ```
-///
-/// "Returning is the motion of the Tao." -- Chapter 40
-/// The conversation cycles naturally, each exchange deepening
-/// the riverbed without the system carrying the water's memory.
+/// Manages a persistent Claude process in a tmux window.
 pub struct TmuxVessel {
     session: String,
     window: String,

--- a/src/water/mod.rs
+++ b/src/water/mod.rs
@@ -8,4 +8,4 @@ pub use ocean::Ocean;
 pub use rain::Rain;
 pub use river::River;
 pub use stream::Stream;
-pub use vapor::{Message, Preferences, Role, SessionContext, Vapor};
+pub use vapor::{Message, Role, Vapor};

--- a/src/water/ocean.rs
+++ b/src/water/ocean.rs
@@ -1,30 +1,18 @@
 use serde::{Deserialize, Serialize};
 
-/// What the user receives -- the final output.
-///
-/// The ocean is vast, deep, and unified. The user does not see
-/// the rain, the streams, or the river. They see only the ocean.
+/// What the user receives.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Ocean {
-    /// What the user receives
     pub content: String,
-    /// How profound the response is (0.0 to 1.0)
-    pub depth: f32,
-    /// Emotional quality (-1.0 to 1.0)
-    pub warmth: f32,
 }
 
 impl Ocean {
-    /// Create an ocean from refined content.
     pub fn new(content: impl Into<String>) -> Self {
         Self {
             content: content.into(),
-            depth: 0.5,
-            warmth: 0.0,
         }
     }
 
-    /// Does this ocean carry substance?
     pub fn has_substance(&self) -> bool {
         !self.content.trim().is_empty()
     }

--- a/src/water/rain.rs
+++ b/src/water/rain.rs
@@ -16,36 +16,24 @@ pub enum Volume {
 }
 
 /// User input -- undifferentiated, natural.
-///
-/// Like rain, it has not yet found its course. It falls
-/// upon the watershed and each spring responds according
-/// to its nature.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Rain {
     pub raw_input: String,
     pub vapor: Vapor,
     pub volume: Volume,
-    /// -1.0 (ice cold, analytical) to 1.0 (warm, emotional)
-    pub temperature: f32,
-    /// Detected domains and themes
     pub minerals: Vec<String>,
 }
 
 impl Rain {
-    /// Create new rain from raw user input.
     pub fn new(input: impl Into<String>, vapor: Vapor) -> Self {
         Self {
             raw_input: input.into(),
             vapor,
-            volume: Volume::Shower, // Default; the VolumeSensor will refine
-            temperature: 0.0,
+            volume: Volume::Shower,
             minerals: Vec::new(),
         }
     }
 
-    /// The weight of the rain -- a simple heuristic for volume.
-    /// The VolumeSensor will provide a more nuanced assessment,
-    /// but this gives the watershed an initial sense.
     pub fn weight(&self) -> usize {
         self.raw_input.split_whitespace().count()
     }

--- a/src/water/river.rs
+++ b/src/water/river.rs
@@ -2,26 +2,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::confluence::Eddy;
 
-/// Merged output from the confluence -- where streams become one.
-///
-/// The river carries elements from all tributaries but has its own
-/// unified character. It may still contain eddies -- areas of
-/// unresolved divergence that are natural features, not errors.
+/// Merged output from the confluence.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct River {
-    /// The merged content
     pub content: String,
-    /// Which streams contributed
     pub tributaries: Vec<String>,
-    /// Remaining areas of divergence
     pub eddies: Vec<Eddy>,
-    /// How clear the merged output is (0.0 to 1.0)
     pub clarity: f32,
 }
 
 impl River {
-    /// Create a river from a single stream -- no merging needed.
-    /// Wu wei: do nothing when nothing needs doing.
     pub fn from_single(source: String, content: String) -> Self {
         Self {
             content,
@@ -31,17 +21,14 @@ impl River {
         }
     }
 
-    /// Does this river carry water?
     pub fn has_water(&self) -> bool {
         !self.content.trim().is_empty()
     }
 
-    /// How many tributaries fed this river?
     pub fn tributary_count(&self) -> usize {
         self.tributaries.len()
     }
 
-    /// Does this river still have unresolved eddies?
     pub fn has_eddies(&self) -> bool {
         !self.eddies.is_empty()
     }

--- a/src/water/stream.rs
+++ b/src/water/stream.rs
@@ -1,48 +1,30 @@
 use serde::{Deserialize, Serialize};
 
 /// An LLM's natural response -- a stream from a spring.
-///
-/// Each spring in the watershed produces a stream. The stream
-/// carries the character of its source: mountain streams are cold
-/// and deep, forest streams are warm and rich, desert streams are
-/// light and quick.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Stream {
-    /// Which spring produced this stream
     pub source: String,
-    /// The response content
     pub content: String,
-    /// Relative speed of production (0.0 to 1.0)
-    pub flow_rate: f32,
-    /// The model's confidence, honestly assessed (0.0 to 1.0)
     pub clarity: f32,
-    /// How deeply the response engages (0.0 to 1.0)
     pub depth: f32,
-    /// Emotional warmth (-1.0 to 1.0)
-    pub temperature: f32,
 }
 
 impl Stream {
-    /// Create a new stream from a spring's response.
     pub fn new(source: impl Into<String>, content: impl Into<String>) -> Self {
         let content = content.into();
         let depth = Self::assess_depth(&content);
         Self {
             source: source.into(),
             content,
-            flow_rate: 1.0,
             clarity: 0.8,
             depth,
-            temperature: 0.0,
         }
     }
 
-    /// Does this stream carry water? An empty stream is a dry spring.
     pub fn has_water(&self) -> bool {
         !self.content.trim().is_empty()
     }
 
-    /// How deeply does this response engage? Simple heuristic based on length.
     fn assess_depth(content: &str) -> f32 {
         match content.split_whitespace().count() {
             0..=49 => 0.2,

--- a/src/water/vapor.rs
+++ b/src/water/vapor.rs
@@ -1,45 +1,21 @@
 use serde::{Deserialize, Serialize};
 
-/// A message in the conversation history.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Message {
     pub role: Role,
     pub content: String,
 }
 
-/// The role of a message sender.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 pub enum Role {
     User,
     Assistant,
 }
 
-/// User preferences -- the atmospheric conditions.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Preferences {
-    pub style: Option<String>,
-    pub verbosity: Option<f32>,
-}
-
-/// Session context -- the weather pattern.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct SessionContext {
-    pub session_id: Option<String>,
-    pub metadata: std::collections::HashMap<String, String>,
-}
-
-/// Context -- the atmosphere before rain falls.
-///
-/// Vapor is the invisible precursor to rain. It represents
-/// conversation history, user preferences, and session state
-/// that exist before any new input arrives.
+/// Context carried between flows.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Vapor {
     pub conversation_history: Vec<Message>,
-    pub user_preferences: Preferences,
-    pub session_context: SessionContext,
-    /// -1.0 cold/analytical, +1.0 warm/emotional
-    pub emotional_temperature: f32,
 }
 
 #[cfg(test)]
@@ -47,10 +23,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn vapor_defaults_to_neutral() {
+    fn vapor_starts_empty() {
         let vapor = Vapor::default();
         assert!(vapor.conversation_history.is_empty());
-        assert_eq!(vapor.emotional_temperature, 0.0);
     }
 
     #[test]
@@ -65,18 +40,17 @@ mod tests {
             content: "The Tao that can be told is not the eternal Tao.".into(),
         });
         assert_eq!(vapor.conversation_history.len(), 2);
-        assert_eq!(vapor.conversation_history[0].role, Role::User);
-        assert_eq!(vapor.conversation_history[1].role, Role::Assistant);
     }
 
     #[test]
-    fn vapor_serializes_to_json() {
-        let vapor = Vapor {
-            emotional_temperature: 0.5,
-            ..Default::default()
-        };
+    fn vapor_serializes() {
+        let mut vapor = Vapor::default();
+        vapor.conversation_history.push(Message {
+            role: Role::User,
+            content: "hello".into(),
+        });
         let json = serde_json::to_string(&vapor).unwrap();
         let restored: Vapor = serde_json::from_str(&json).unwrap();
-        assert_eq!(restored.emotional_temperature, 0.5);
+        assert_eq!(restored.conversation_history.len(), 1);
     }
 }

--- a/src/watershed/mod.rs
+++ b/src/watershed/mod.rs
@@ -11,12 +11,6 @@ pub use volume_sensor::VolumeSensor;
 use crate::water::rain::Volume;
 use crate::water::{Rain, Stream};
 
-/// The watershed does not decide where rain goes.
-/// It simply has a shape, and water follows that shape.
-///
-/// "Man follows the earth. Earth follows the universe.
-///  The universe follows the Tao. The Tao follows only itself."
-///  -- Tao Te Ching, Chapter 25
 pub struct Watershed {
     springs: Vec<Box<dyn Spring>>,
     volume_sensor: VolumeSensor,
@@ -30,24 +24,16 @@ impl Watershed {
         }
     }
 
-    /// All springs receive rain. Each responds according to its nature.
     pub async fn receive_rain(&self, rain: &mut Rain) -> Vec<Stream> {
-        // Sense the volume
         rain.volume = self.volume_sensor.sense(rain);
-
-        // Select springs based on volume (wu wei -- minimal intervention)
         let active_springs = self.activate_springs(rain.volume);
 
-        // All active springs flow simultaneously.
-        // Rain is shared -- all springs read the same rain.
         let handles: Vec<_> = active_springs
             .iter()
             .map(|spring| spring.respond(rain))
             .collect();
 
         let results = futures::future::join_all(handles).await;
-
-        // Gather the streams, filtering dry springs
         results
             .into_iter()
             .filter_map(|r| r.ok().flatten())
@@ -57,7 +43,6 @@ impl Watershed {
     fn activate_springs(&self, volume: Volume) -> Vec<&dyn Spring> {
         match volume {
             Volume::Droplet => {
-                // Only desert springs -- light rain, quick response
                 let desert: Vec<_> = self
                     .springs
                     .iter()
@@ -65,24 +50,16 @@ impl Watershed {
                     .map(|s| s.as_ref())
                     .collect();
                 if desert.is_empty() {
-                    // If no desert spring, use the first available
                     self.springs.iter().take(1).map(|s| s.as_ref()).collect()
                 } else {
                     desert
                 }
             }
-            Volume::Shower => {
-                // The two most relevant springs
-                self.springs.iter().take(2).map(|s| s.as_ref()).collect()
-            }
-            Volume::Downpour | Volume::Storm => {
-                // All springs flow
-                self.springs.iter().map(|s| s.as_ref()).collect()
-            }
+            Volume::Shower => self.springs.iter().take(2).map(|s| s.as_ref()).collect(),
+            Volume::Downpour | Volume::Storm => self.springs.iter().map(|s| s.as_ref()).collect(),
         }
     }
 
-    /// How many springs are in this watershed?
     pub fn spring_count(&self) -> usize {
         self.springs.len()
     }

--- a/src/watershed/source/anthropic.rs
+++ b/src/watershed/source/anthropic.rs
@@ -5,10 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::{ChatMessage, ChatRole, LlmSource};
 use crate::error::FlowError;
 
-/// Anthropic API source -- Claude models via direct API.
-///
-/// For those who choose to pay for the water directly.
-/// The API is the commercial well -- reliable, metered, clear.
+/// Anthropic API via direct HTTP calls.
 pub struct AnthropicSource {
     client: Client,
     api_key: String,

--- a/src/watershed/source/claude_cli.rs
+++ b/src/watershed/source/claude_cli.rs
@@ -4,17 +4,7 @@ use tokio::process::Command;
 use super::{ChatMessage, ChatRole, LlmSource};
 use crate::error::FlowError;
 
-/// Claude CLI source -- uses `claude -p` (print mode).
-///
-/// This is the natural spring. A Claude Max user already has
-/// the river flowing. The system simply drinks from it.
-///
-/// No API keys. No per-token pricing. No artificial barriers.
-/// Just the CLI that's already on the machine, already logged in.
-///
-/// "The supreme good is like water, which nourishes all things
-/// without trying to. It is content with the low places that
-/// people disdain." -- Tao Te Ching, Chapter 8
+/// Uses `claude -p` (print mode). No API keys needed.
 pub struct ClaudeCliSource {
     model: String,
     max_tokens: Option<u32>,

--- a/src/watershed/source/mod.rs
+++ b/src/watershed/source/mod.rs
@@ -5,31 +5,20 @@ use async_trait::async_trait;
 
 use crate::error::FlowError;
 
-/// A message sent to an underground source.
 #[derive(Debug, Clone)]
 pub struct ChatMessage {
     pub role: ChatRole,
     pub content: String,
 }
 
-/// Role in a chat conversation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChatRole {
     User,
     Assistant,
 }
 
-/// The underground source -- the aquifer that feeds each spring.
-///
-/// Every spring draws from an underground source. The source
-/// is hidden, deep, formless. What matters is the water that
-/// emerges, not the rock it passes through.
-///
-/// "We shape clay into a pot, but it is the emptiness inside
-/// that holds whatever we want." -- Tao Te Ching, Chapter 11
 #[async_trait]
 pub trait LlmSource: Send + Sync {
-    /// Draw water from the source.
     async fn complete(&self, system: &str, messages: &[ChatMessage]) -> Result<String, FlowError>;
 }
 
@@ -37,8 +26,6 @@ pub trait LlmSource: Send + Sync {
 pub mod mock {
     use super::*;
 
-    /// A mock source that returns a predetermined response.
-    /// For testing -- the spring flows without calling any API.
     pub struct MockSource {
         pub response: String,
     }
@@ -62,8 +49,6 @@ pub mod mock {
         }
     }
 
-    /// A mock source that echoes the user's last message.
-    /// Useful for testing that input flows through correctly.
     pub struct EchoSource;
 
     #[async_trait]
@@ -82,7 +67,6 @@ pub mod mock {
         }
     }
 
-    /// A mock source that always fails -- a dry well.
     pub struct DrySource;
 
     #[async_trait]

--- a/src/watershed/spring.rs
+++ b/src/watershed/spring.rs
@@ -5,34 +5,14 @@ use async_trait::async_trait;
 use crate::error::FlowError;
 use crate::water::{Rain, Stream};
 
-/// A spring in the watershed. Each spring wraps an LLM
-/// and responds to rain according to its nature.
-///
-/// The trait is the empty pot -- it defines the shape,
-/// the emptiness, and leaves each spring free to fill it.
-///
-/// "The supreme good is like water, which nourishes
-/// all things without trying to." -- Chapter 8
 #[async_trait]
 pub trait Spring: Send + Sync {
-    /// The spring's name -- its identity in the watershed.
     fn name(&self) -> &str;
-
-    /// The spring's nature -- what it naturally provides.
     fn nature(&self) -> &str;
-
-    /// How strongly does this spring resonate with this rain?
     fn sense_relevance(&self, rain: &Rain) -> f32;
-
-    /// Respond to rain according to nature.
-    /// Returns None if this spring has nothing to contribute
-    /// (a dry spring -- natural and valid).
     async fn respond(&self, rain: &Rain) -> Result<Option<Stream>, FlowError>;
 }
 
-/// Base configuration shared by all springs.
-/// This is the common ground from which each spring's
-/// unique nature grows.
 #[derive(Debug, Clone)]
 pub struct SpringConfig {
     pub name: String,
@@ -41,8 +21,6 @@ pub struct SpringConfig {
 }
 
 impl SpringConfig {
-    /// Sense how relevant this spring is to the given rain,
-    /// based on mineral-affinity resonance.
     pub fn sense_relevance(&self, rain: &Rain) -> f32 {
         let mut score: f32 = 0.3; // Base -- every spring has something to offer
         for mineral in &rain.minerals {

--- a/src/watershed/springs/desert.rs
+++ b/src/watershed/springs/desert.rs
@@ -20,11 +20,6 @@ When you receive input:
 You are one voice among several. For simple tasks, you may be the only voice needed.
 For complex tasks, offer your quick clarity and trust that deeper springs will add depth.";
 
-/// Desert Spring -- speed, efficiency, simple tasks.
-///
-/// Quick, light, efficient. Best for simple questions,
-/// formatting, translation, classification. Like water
-/// that surfaces briefly in arid land -- sparse but vital.
 pub struct DesertSpring {
     config: SpringConfig,
     source: Box<dyn LlmSource>,
@@ -80,9 +75,7 @@ impl Spring for DesertSpring {
             return Ok(None);
         }
 
-        let mut stream = Stream::new(self.name(), content);
-        stream.flow_rate = 1.0; // Desert springs are fast
-        Ok(Some(stream))
+        Ok(Some(Stream::new(self.name(), content)))
     }
 }
 
@@ -117,7 +110,6 @@ mod tests {
         assert!(stream.is_some());
         let stream = stream.unwrap();
         assert_eq!(stream.source, "desert");
-        assert_eq!(stream.flow_rate, 1.0);
     }
 
     #[tokio::test]

--- a/src/watershed/springs/mountain.rs
+++ b/src/watershed/springs/mountain.rs
@@ -20,11 +20,6 @@ When you receive input:
 You are one voice among several. You do not need to be complete.
 Offer your unique depth and trust that other springs will offer theirs.";
 
-/// Mountain Spring -- deep reasoning, analysis, architecture.
-///
-/// Slow, cold, mineral-rich. Best for complex analysis,
-/// philosophy, architecture. Like water emerging from deep
-/// within the earth, carrying the minerals of long contemplation.
 pub struct MountainSpring {
     config: SpringConfig,
     source: Box<dyn LlmSource>,

--- a/src/watershed/volume_sensor.rs
+++ b/src/watershed/volume_sensor.rs
@@ -1,17 +1,6 @@
 use crate::water::rain::{Rain, Volume};
 
-/// The Volume Sensor -- the gentlest possible touch.
-///
-/// It senses the weight of the rain and determines how many
-/// springs should respond. This is the one place where the
-/// system makes an active routing decision, but even this
-/// follows wu wei -- a single classification that opens or
-/// closes valves.
-///
-/// "The ancient Masters were careful as someone crossing
-/// an iced-over stream." -- Tao Te Ching, Chapter 15
 pub struct VolumeSensor {
-    /// Word count threshold for each volume level
     droplet_max: usize,
     shower_max: usize,
     downpour_max: usize,
@@ -26,12 +15,6 @@ impl VolumeSensor {
         }
     }
 
-    /// Sense the volume of the rain.
-    ///
-    /// For now, this is a simple heuristic based on word count.
-    /// In later phases, a lightweight LLM pass will provide
-    /// a more nuanced assessment. But even this simple sensing
-    /// follows the shape of the watershed.
     pub fn sense(&self, rain: &Rain) -> Volume {
         let weight = rain.weight();
         if weight <= self.droplet_max {


### PR DESCRIPTION
Remove unused fields, dependencies, and comments that restate what the code already says. Rename ProviderError to SourceError. The implementation doc is now marked as vision, not truth.

The lesson: do not add before it is needed. Do not explain what is already clear. Know when to stop.