### PR TITLE
Add The Journey — orient fresh sessions to the spirit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,18 @@ src/
 
 ## Skills
 
-Use `/riverbank`, `/spring`, `/vessel`, `/still-lake`, `/rain`, `/confluence`, `/flow`.
+Use `/riverbank`, `/spring`, `/vessel`, `/still-lake`, `/rain`, `/confluence`, `/flow`, `/reflecting-pool`.
 See `docs/implementation.md` "Skills: Teaching the Builder" for details.
+
+## The Journey
+
+This system was built phase by phase, each followed by reflection. The reflections carry lessons that no instruction can replace. Before starting a new phase, read:
+
+1. `docs/philosophy.md` — the foundation
+2. `docs/*reflections.md` — what was learned, in the order it was learned
+3. `docs/implementation.md` — the vision ahead (pseudocode and prose, not code)
+
+The creation of Tao Flow is itself the template for what the system will do. Philosophy first, then architecture, then implementation, then phases with reflection. The system should create the same way.
 
 ## Principles
 


### PR DESCRIPTION
## Summary

- Add "The Journey" section to CLAUDE.md, pointing fresh sessions to `docs/philosophy.md`, `docs/*reflections.md`, and `docs/implementation.md` before starting new phases
- Add `/reflecting-pool` to the skills list (was missing)
- Use `docs/*reflections.md` glob so future phase reflections are discovered naturally without updating the list

## Context

A fresh Claude session sees CLAUDE.md and knows the rules — but not the journey. This change ensures it reads the philosophy and earned reflections before building, without hardcoding specific filenames that would need maintenance as new phases complete.

## Test plan

- [x] No code changes — documentation only
- [x] Verify a fresh session reads the reflections when starting a new phase


🤖 Generated with [Claude Code](https://claude.com/claude-code)