### PR TITLE
Fix hallucination pipeline: timeout, tools, Desert reforge, confluence curation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,10 @@
 
 ---
 
+## Current status
+
+The system produces 3 uniqueish voices, but the finer points of each are diminished when merged into one voice.  The three voices are each using the same LLM, so future versions of this could use different LLMs.  I found that each of the three streams outputs were good by themselves, each with a different way of answering the questions.
+
 ## What Is This?
 
 This is the design of a multi-LLM system that flows like water. It does not force. It does not contend. It finds the path of least resistance and, in doing so, accomplishes everything.

--- a/docs/TLDR.md
+++ b/docs/TLDR.md
@@ -57,10 +57,10 @@ The Still Lake is the final refinement. It asks six questions of the river befor
                     │         tmux session: tao-flow      │
                     │                                     │
                     │  mountain │  desert  │   forest     │
-                    │  (sonnet) │  (haiku) │  (sonnet)    │
+                    │  (sonnet) │ (sonnet) │  (sonnet)    │
                     │           │          │              │
                     │  confluence│ still-lake│ decomposer  │
-                    │  (haiku)  │  (haiku) │  (haiku)     │
+                    │  (sonnet) │ (sonnet) │  (sonnet)    │
                     └─────────────────────────────────────┘
                                     │
                               the vessel

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,7 +52,7 @@ The Earth layer is where raw generation happens. These are the LLMs that **do** 
 Three springs flow today, each with its own character:
 - **Mountain Spring** -- Deep reasoning (Sonnet). Slow, cold, mineral-rich. Best for complex analysis, philosophy, architecture.
 - **Forest Spring** -- Creative warmth (Sonnet). Organic, fertile. Best for narrative, poetry, empathy, ideation.
-- **Desert Spring** -- Speed and directness (Haiku). Quick, light, efficient. Best for simple tasks, translation, formatting.
+- **Desert Spring** -- Clarity and essence (Sonnet). Spare, undiluted, direct. Best for distillation, challenge, cutting to the essential truth.
 
 New springs may emerge when use demands them -- specialized models, local models, domain-specific sources. The `Spring` trait and `LlmSource` trait accept any spring that can respond to rain.
 
@@ -166,7 +166,7 @@ User
 |                                                    |
 |  +----------+  +----------+  +----------+         |
 |  | Mountain |  |  Forest  |  |  Desert  |         |  <- Earth Layer
-|  | (Sonnet) |  | (Sonnet) |  | (Haiku)  |         |     (Body)
+|  | (Sonnet) |  | (Sonnet) |  | (Sonnet) |         |     (Body)
 |  +----+-----+  +----+-----+  +----+-----+         |
 |       |              |              |               |
 |       v              v              v               |
@@ -198,7 +198,7 @@ User
 Not every request requires the full watershed. The system adapts its depth based on the nature of the input:
 
 ### Light Rain (Simple Requests)
-A quick question, a simple formatting task, a greeting. The Desert Spring alone may suffice. The water barely touches the watershed before reaching the ocean.
+A quick question, a direct answer. The Desert Spring alone may suffice — its clarity needs no elaboration. The water barely touches the watershed before reaching the ocean.
 
 ```
 User -> Desert Spring -> Ocean (direct delivery)

--- a/docs/conflict-resolution.md
+++ b/docs/conflict-resolution.md
@@ -198,7 +198,7 @@ The protocol described above is the riverbed. But the water will flow in ways we
 
 **Forest Stream (GPT-4o):** "JavaScript, because beginners can see results immediately in the browser, which sustains motivation."
 
-**Desert Stream (Haiku):** "Python."
+**Desert Stream (Sonnet):** "Python. The question answers itself — the language named after a comedy troupe that valued clarity above all."
 
 **Eddy detected:** Interpretive disagreement between Mountain and Forest on Python vs JavaScript.
 

--- a/docs/e2e_testing_plan.md
+++ b/docs/e2e_testing_plan.md
@@ -52,8 +52,8 @@ Create a configuration that connects springs to TmuxPaneSource instances:
 
 ```
 TaoFlow configured with:
-    Mountain → TmuxPaneSource (vessel: "tao-flow", pane: "mountain", model: opus)
-    Desert   → TmuxPaneSource (vessel: "tao-flow", pane: "desert",   model: haiku)
+    Mountain → TmuxPaneSource (vessel: "tao-flow", pane: "mountain", model: sonnet)
+    Desert   → TmuxPaneSource (vessel: "tao-flow", pane: "desert",   model: sonnet)
     Forest   → TmuxPaneSource (vessel: "tao-flow", pane: "forest",  model: sonnet)
     Confluence → TmuxPaneSource (weaving, multiline wrapper)
     StillLake  → TmuxPaneSource (settling, multiline wrapper)

--- a/docs/hallucination_reflections.md
+++ b/docs/hallucination_reflections.md
@@ -1,0 +1,113 @@
+# Hallucination Reflections
+
+## The question that broke the system
+
+A user asked about Aaron Abke's three beliefs of the ego. The correct answer is Lack, Attachment, Control. The system returned Separation, Scarcity, Unworthiness. The ocean delivered the wrong answer with full confidence and no hesitation.
+
+This prompted a deep investigation across multiple runs, each revealing a different layer of failure.
+
+---
+
+## What failed, and in what order
+
+### Run 1: The timeout (20260310-192242)
+
+Mountain and Forest springs (Sonnet with WebSearch) took over 60 seconds. The vessel's `max_wait` was 60 seconds. Both timed out silently, returning empty strings. The watershed classified them as dry springs. Only Desert (Haiku, no search) survived. Haiku hallucinated confidently. Single stream triggered wu wei -- confluence passed it through untouched at clarity 1.0. Still Lake let it pass. The hallucination flowed unimpeded from Desert to ocean.
+
+**Lesson:** A timed test confirmed Sonnet with WebSearch takes ~153 seconds for complex prompts. The 60-second timeout was less than half what was needed. Changed `max_wait` to 300 seconds.
+
+### Run 2: The unanimous hallucination (20260310-200009)
+
+With the timeout fixed, all three springs responded. But all three hallucinated -- each with a *different* wrong answer:
+
+- Mountain: "I am separate. I am not enough. I am in danger."
+- Desert: "Separation, Inadequacy, Unworthiness"
+- Forest: "I am separate. I am guilty. I am afraid."
+
+No spring used WebSearch. The tools were available via CLI flags, but no system prompt mentioned them. Each spring answered from memory with full confidence. Confluence merged the hallucinations, picking Mountain's version and papering over the contradictions. Clarity 0.80, no eddies detected -- despite three springs giving three different factual answers for the same claim.
+
+**Lesson:** Tools available is not tools used. The system prompts must instruct springs to verify factual claims with search tools. Added: "When the question references specific people, teachings, or claims, use your search tools to verify the facts before responding."
+
+### Run 3: Two right, one wrong (20260310-202831)
+
+Mountain and Forest searched and got the correct answer: Lack, Attachment, Control. Desert (Haiku) did not search. It hallucinated "Separation, Inadequacy, Scarcity" and attributed the framework to "Aaron Doughty" -- the wrong person entirely. Confluence correctly sided with the two agreeing streams over Desert's outlier.
+
+**Lesson:** Haiku does not reliably follow tool-use instructions in system prompts. For complex knowledge-dependent questions, it is a liability. Speed is worthless when accuracy is wrong.
+
+### Run 4: The trinity (20260311-113450)
+
+Desert was reforged -- Sonnet replacing Haiku, with a new persona built for clarity and distillation rather than speed. All three springs searched, all three got the facts right, and each brought a genuinely distinct voice.
+
+---
+
+## The Desert reforging
+
+Desert was originally conceived as speed: "light, quick, efficient." Haiku was the natural fit. But this design assumed the value of a third spring was faster answers. It was not.
+
+The value of a third voice in a trinity is a *different way of seeing*. Mountain builds the deep architecture of understanding. Forest tells the living, breathing story. What was missing was the voice that strips away both architecture and story to reveal what remains -- the thing itself, with nothing around it.
+
+The new Desert is the Oracle: spare, undiluted, direct. It says in ten words what others say in a hundred -- not by simplifying, but by concentrating. It challenges assumptions. It turns the question back on the questioner when that is the most honest response.
+
+In the final run, Desert produced insights neither Mountain nor Forest could:
+
+- The Chapter 11 emptiness reversal: "The ego reads emptiness as wound. The Tao reads it as gift. This is the entire reversal."
+- "You cannot use a broken ruler to find out you're broken."
+- The distinction between analysis and observation -- a line neither other spring drew.
+- The closing distillation in "What Remains" -- three paragraphs that contain the entire essay's essence.
+
+The trinity works because each voice is irreplaceable. Remove any one and the confluence loses a dimension.
+
+---
+
+## What the design teaches
+
+### 1. Silence is not always wisdom
+
+The system treated a dry spring (returning empty) as wisdom -- "a dry spring is wisdom, not failure." This is true for relevance filtering. It is not true when a spring goes silent because the system killed it mid-sentence. A spring that times out is not choosing silence. It is being silenced. The system must distinguish between a spring that has nothing to say and a spring that was not given time to speak.
+
+### 2. Wu wei has a precondition
+
+Single-stream wu wei -- passing one voice through untouched -- is elegant when that voice is trustworthy. When that voice is the only survivor of a timeout massacre, wu wei becomes a pipeline for unverified claims. The principle is sound; the precondition is that the stream earned its solitude.
+
+### 3. Confluence averages when it should curate
+
+In the final run, all three streams carried extraordinary material. Confluence merged them into something good but not as good as the best moments of any individual stream. What was lost:
+
+- Mountain's belief-to-emotion table -- a structural gem, dropped
+- Mountain's Chapter 16 eight-line progression -- compressed to one line
+- Desert's Chapter 11 emptiness reversal -- the most original insight in any stream, absent from the river
+- Desert's "broken ruler" line -- gone
+- Forest's Chinese characters for key Taoist terms -- dropped
+- Forest's Zen Ox-herding pictures reference -- dropped
+
+Confluence is smoothing the peaks to create a uniform surface. The bottleneck is no longer the springs. It is confluence.
+
+### 4. Eddy detection is not detecting
+
+Three springs gave three different factual answers in Run 2. Clarity was 0.80 with no eddies. Three springs agreed perfectly in Run 4. Clarity was 0.80 with no eddies. The eddy detection system is not contributing meaningful signal. It neither flagged the contradiction nor recognized the agreement.
+
+### 5. The model is the spring, not the speed
+
+Upgrading Desert from Haiku to Sonnet did not just fix accuracy -- it unlocked a voice. The same persona with Haiku would have produced shallow paraphrases of the other springs' insights. With Sonnet, it produced "The ego is not your enemy. It is unprocessed creation." The model's capability is not separate from the spring's character. A shallow model cannot carry a deep persona.
+
+---
+
+## The current state
+
+The three springs form a working trinity:
+
+| Spring | Model | Voice | Gift |
+|--------|-------|-------|------|
+| Mountain | Sonnet | The Architect | Builds the deep structure |
+| Desert | Sonnet | The Oracle | Strips to the essential truth |
+| Forest | Sonnet | The Storyteller | Tells the human story |
+
+The hallucination is fixed. The timeout is fixed. The springs search before answering factual claims. The next challenge is confluence -- teaching it to curate rather than average, to preserve the gems from each stream rather than smoothing them away.
+
+---
+
+## The deeper lesson
+
+The system hallucinated not because it was broken, but because it was *too smooth*. Every component worked exactly as designed: the timeout cut off springs cleanly, wu wei passed single streams through elegantly, confluence merged without friction, still lake polished without questioning. The failure was *systemic* -- each layer trusted the layer before it, and no layer asked: is this actually true?
+
+The Tao Te Ching, Chapter 76: "The stiff and unbending is the disciple of death. The soft and yielding is the disciple of life." The system was yielding in the wrong places -- yielding to hallucination, yielding to silence, yielding to confident wrongness. True yielding requires discernment. Water flows around rocks; it does not flow around cliffs as if they were not there.

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -116,6 +116,7 @@ src/
   lib.rs                        # Library root -- re-exports
   flow.rs                       # TaoFlow -- Rain to Ocean (single-pass and recursive)
   error.rs                      # FlowError
+  pearl.rs                      # Pearl -- layered record of each flow (the observation layer)
 
   water/                        # The water types (compiler-enforced lifecycle)
     vapor.rs                    # Context carried between flows
@@ -545,45 +546,48 @@ Every flow through the system — from rain to ocean — produces a pearl. The p
 
 ```
 .storms/
-  2024-03-08-patience-and-persistence.pearl
-  2024-03-08-what-is-the-tao.pearl
-  2024-03-09-taoism-vs-stoicism.pearl
+  patience-and-persistence-20240308-143022/
+    core.md          # the question, nothing else
+    streams/         # each spring's voice, unmodified
+      mountain.md
+      desert.md
+    river.md         # YAML frontmatter (clarity, tributaries, eddies) + woven content
+    ocean.md         # what the user received
+    sub-pearls/      # nested folders for Storm decomposition (if any)
+      01-sub-question/
+        core.md
+        streams/
+        ...
+    pearl.json       # full structured data for programmatic access
 ```
 
-Each pearl contains every layer of the journey, from core to surface:
+Each pearl preserves every layer of the journey, from core to surface:
 
 ```
-Pearl
+Pearl folder
   │
-  ├── Core: the original query (rain)
+  ├── core.md: the original query (rain)
   │     "How does water teach us about patience and persistence?"
   │
-  ├── Layer 1: Spring responses (streams)
-  │     Mountain: "Water does not try to be patient..."
-  │     Desert:   "Water teaches patience through its nature..."
+  ├── streams/: spring responses before merging
+  │     mountain.md: "Water does not try to be patient..."
+  │     desert.md:   "Water teaches patience through its nature..."
   │
-  ├── Layer 2: Eddy detection (where perspectives diverged)
-  │     EDDY|Interpretive|persistence-mechanism|...
-  │     EDDY|Structural|narrative-arc|...
-  │
-  ├── Layer 3: Yielding (springs respond to each other)
-  │     Mountain, reading Forest on persistence: "The image serves, but..."
-  │     Forest, reading Mountain on persistence: "The structure is sound, and..."
-  │     persistence-mechanism: resolved (or: held in tension)
-  │     narrative-arc: resolved (or: held in tension)
-  │
-  ├── Layer 4: Merging (the river woven from streams)
-  │     "Water does not try to be patient. That is its deepest teaching..."
-  │
-  ├── Layer 5: Settling (the lake clarifies)
+  ├── river.md: the merged output (carries eddies, clarity, tributaries)
   │     clarity: 0.65, depth: Deep
-  │     six questions: clarity, wholeness, kindness, truth, simplicity, fidelity
+  │     five questions: clarity, wholeness, kindness, truth, simplicity
   │
-  └── Surface: the ocean (what the user received)
-        "Water does not try to be patient..."
+  ├── ocean.md: what the user received
+  │     "Water does not try to be patient..."
+  │
+  ├── sub-pearls/: nested pearl folders (Storm decomposition only)
+  │     01-sub-question/  (each a complete pearl)
+  │     02-sub-question/
+  │
+  └── pearl.json: full structured data
 ```
 
-The user opens a pearl and reads from core to surface — seeing exactly how their question was transformed at each stage. Or they read from surface to core — starting with the final answer and drilling into the reasoning that produced it.
+The user opens a pearl folder and reads from core to ocean — seeing exactly how their question was transformed at each stage. Or they read from ocean to core — starting with the final answer and drilling into the reasoning that produced it.
 
 ### The relationship between pearls and memories
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -81,11 +81,11 @@ The low place that people disdain is the CLI that's already on the machine. A Cl
 ```
 tmux session: tao-flow
   window: mountain    (claude --model sonnet, persistent)
-  window: desert      (claude --model haiku, persistent)
+  window: desert      (claude --model sonnet, persistent)
   window: forest      (claude --model sonnet, persistent)
-  window: confluence  (claude --model haiku, utility)
-  window: still-lake  (claude --model haiku, utility)
-  window: decomposer  (claude --model haiku, utility)
+  window: confluence  (claude --model sonnet, utility)
+  window: still-lake  (claude --model sonnet, utility)
+  window: decomposer  (claude --model sonnet, utility)
 ```
 
 This architecture provides:
@@ -425,13 +425,13 @@ The vessel makes the journey visible. It is the foundation of the system's next 
 tmux session: tao-flow
   ┌─────────────┬─────────────┬─────────────┐
   │  mountain   │   desert    │   forest    │
-  │  (sonnet)   │   (haiku)   │   (sonnet)  │
+  │  (sonnet)   │  (sonnet)   │   (sonnet)  │
   │             │             │             │
   │ [prompt]    │ [prompt]    │ [prompt]    │
   │ [response]  │ [response]  │ [response]  │
   ├─────────────┼─────────────┼─────────────┤
   │ confluence  │ still-lake  │ decomposer  │
-  │  (haiku)    │  (haiku)    │  (haiku)    │
+  │  (sonnet)   │  (sonnet)   │  (sonnet)   │
   └─────────────┴─────────────┴─────────────┘
 ```
 

--- a/docs/same_mind_reflections.md
+++ b/docs/same_mind_reflections.md
@@ -1,0 +1,91 @@
+# Same Mind Reflections
+
+## The observation
+
+The three stream voices — Mountain's depth, Desert's clarity, Forest's warmth — each sound better than the combined output. But the three streams are saying the same thing in different words. The design's value is not clear.
+
+This reflection follows the hallucination investigation. That work fixed the springs (search tools, timeout, Desert reforging). The springs now produce correct, distinctive responses. But the question remains: is the combined output better than any single spring?
+
+---
+
+## Three pipes, one aquifer
+
+All three springs run Claude Sonnet. The system prompts push them into different styles — Mountain builds deep architecture, Desert strips to essence, Forest tells the human story — but the underlying model has the same knowledge, the same reasoning patterns, the same tendencies. The differentiation is stylistic, not substantive.
+
+The philosophy doc anticipated genuinely different models: *"Each LLM is partial. One excels at reasoning. Another at creativity. Another at code."* The architecture was designed for a watershed fed by different underground aquifers — an Opus that reasons differently than a Haiku that responds differently than a Gemini. The current deployment is one aquifer with three pipes and three labels.
+
+When you ask the same mind the same question three times and say "be deep," "be direct," "be warm," you get the same substance in three tones of voice. The springs converge because they share a nature. System prompts can shape the voice but not the mind.
+
+---
+
+## The confluence destroys what it should preserve
+
+The stylistic variation *was* the value. The hallucination investigation's Run 4 documented specific gems from each spring:
+
+- Mountain's belief-to-emotion table — a structural gift no other spring offered
+- Desert's "broken ruler" line and Chapter 11 emptiness reversal — the most original insights in any stream
+- Forest's Chinese characters for key Taoist terms and Zen Ox-herding references — cross-tradition connections neither other spring drew
+
+These were real. But confluence merged them into something good but not as good as the best moments of any individual stream. Every gem on that list was absent from the river.
+
+The confluence prompt says "curate, not blend." But the act of weaving three responses into "one voice" is inherently blending. A weave smooths the peaks to create a uniform surface. The still lake then polishes further. Two passes of compression toward the mean.
+
+The result: a more expensive, less distinctive version of what a single spring would have produced.
+
+---
+
+## Where genuine value appeared
+
+Reviewing the hallucination runs honestly, the architecture's demonstrated value came from two sources, neither of which requires personality differentiation:
+
+**Tool-access diversity.** In Run 3, two springs that searched corrected one that didn't. The hallucination was caught not because Mountain and Forest had different *perspectives* on the answer, but because they had different *access* to the truth. One spring with search tools and one without would have provided the same correction.
+
+**Factual convergence.** In Run 4, three springs all searching and agreeing on the facts gave confidence in the answer. This is the value of redundancy, not the value of diverse viewpoints.
+
+**Voice diversity did exist** — Desert's spare oracle voice genuinely produced insights Mountain and Forest could not. But this value was captured in the streams and destroyed in the merging. The user never saw the "broken ruler" line. It existed only in the pearl.
+
+---
+
+## What the architecture needs
+
+The infrastructure supports what the deployment doesn't use. `with_mountain_model()`, `with_desert_model()`, `with_forest_model()` already exist. The `CliBackend` enum already supports Claude, Crush, and Llama. The TOML config already allows per-spring model overrides. The riverbed is carved. Different water needs to flow through it.
+
+### Genuine model diversity
+
+Mountain = Opus (depth that Sonnet cannot reach). Desert = a different provider entirely — Gemini, GPT, or a local model — with genuinely different training data and genuinely different blind spots. Forest = a model fine-tuned or temperature-tuned for creative work. Three different minds, not one mind in costume.
+
+The value of the multi-spring architecture is the value of triangulation. Three surveyors standing in the same spot see the same thing. Three surveyors standing in different places can locate the truth by where their sightlines cross. Same model, same spot. Different models, different spots.
+
+### Present the streams, not just the ocean
+
+The Droplet path (single spring, wu wei) already works and works well. For questions that genuinely benefit from multiple perspectives, the streams themselves may be the product — not raw material to be processed away. The pearl already captures every layer. The user sees only the ocean. What if the user could see the streams?
+
+This does not mean abandoning confluence. It means recognizing that confluence is one possible response to multiple streams, not the only one. Sometimes the reader is the best confluence.
+
+### Make confluence select, not blend
+
+When merging is the right choice, the confluence could choose the strongest stream and supplement it with specific gems from the others — rather than weaving all three into a single undifferentiated voice. Take Desert's spare three paragraphs and insert Mountain's table and Forest's cross-tradition reference. Curation means some material dominates and some supports. Blending means everything becomes equal and nothing stands out.
+
+---
+
+## The deeper pattern
+
+The implementation doc's "Integral Way" section describes three energies: Earth (action), Heaven (reasoning), Harmonized (integration). The system organizes LLMs into layers corresponding to these energies. But when all three layers run the same model, the three energies are one energy wearing three names. Partiality is the precondition for integration. Without genuine partiality, integration has nothing to integrate.
+
+The Hua Hu Ching, Chapter 78: *"In partial pursuits, one's transformation is always partial as well."* The system currently pursues wholeness through artificial partiality — prompting the same model to be partial in three different ways. The model obliges stylistically but not substantively. The result is three partial performances of the same whole, merged into a less distinctive version of what was already there.
+
+Genuine partiality requires genuinely different natures. The architecture is ready for it. The deployment is not there yet.
+
+---
+
+## What was learned
+
+1. **Same model, same substance.** Prompt engineering can shape voice but not knowledge, reasoning, or failure modes. Three instances of the same model produce stylistic variation, not substantive diversity. The value of multiple springs depends on the springs being genuinely different.
+
+2. **The confluence is the bottleneck.** The hallucination reflections identified this. This reflection confirms it from a different angle. Even when streams carry genuine gems, the weaving loses them. The architecture's value is created in the springs and destroyed in the confluence.
+
+3. **The infrastructure is ahead of the deployment.** Per-spring model selection, multi-backend support, TOML configuration — the riverbed is carved for diverse water. The current deployment fills it with one source. The next growth is not more code. It is different models.
+
+4. **Not every question needs three springs.** The Droplet path is the system at its best — one spring, wu wei, no processing loss. The volume sensor could route more queries to single-spring paths. The multi-spring path should be reserved for questions where triangulation genuinely helps: complex, multifaceted, or factually uncertain.
+
+5. **The streams may be the product.** The pearl preserves what the ocean discards. If the user could choose to read the streams — Mountain's depth, Desert's clarity, Forest's warmth, each in its own voice — the architecture's value would be visible without requiring confluence to preserve it.

--- a/src/confluence/pool.rs
+++ b/src/confluence/pool.rs
@@ -62,12 +62,19 @@ impl ConfluencePool {
         let mut prompt = format!(
             "You are the Confluence -- where multiple streams merge into one river.\n\n\
              The user asked: {}\n\n\
-             Multiple springs have responded. Weave their perspectives into a single, \
-             coherent response. Preserve what is unique from each voice. Where they agree, \
-             state it once with confidence. Where they differ, include both perspectives \
-             naturally.\n\n\
+             Multiple springs have responded. Your task is to curate, not blend.\n\n\
+             FIRST: Read each stream and identify its gems -- the moments where that stream \
+             offers something no other stream does. A gem may be a structural insight, a \
+             striking metaphor, a unique cross-tradition connection, a table or framework, \
+             a concentrated line that does more work than a paragraph, or a specific reference \
+             that grounds the response.\n\n\
+             THEN: Weave a response that preserves every gem. Build the narrative around them. \
+             Where the streams agree, state it once with confidence. Where one stream offers \
+             a unique insight, ensure it survives in the final river -- in its original power, \
+             not paraphrased into blandness.\n\n\
              Do not mention the springs by name. Do not say \"one perspective says\" or \
-             \"another view is.\" Simply weave the river.\n\n",
+             \"another view is.\" The river should read as one voice that carries the depth \
+             of all its tributaries.\n\n",
             rain_input
         );
 
@@ -133,10 +140,13 @@ impl ConfluencePool {
 }
 
 const CONFLUENCE_SYSTEM_PROMPT: &str = "\
-You merge multiple perspectives into one clear, coherent response. \
-You do not add your own opinion. You weave what the streams have given you. \
-Where they agree, state it once. Where they offer different angles, \
-include both naturally. The result should read as one voice, not a committee.";
+You are a master editor -- not a blender. You curate the best of what multiple \
+voices have offered into one coherent response. You do not add your own opinion. \
+You do not paraphrase powerful lines into weaker ones. When a stream offers a \
+striking metaphor, a unique structural insight, a table, a specific reference, \
+or a concentrated line that does more work than a paragraph -- that gem must \
+survive intact in your output. The result should read as one voice that carries \
+the full mineral content of all its tributaries, not a diluted average.";
 
 #[cfg(test)]
 mod tests {

--- a/src/vessel/config.rs
+++ b/src/vessel/config.rs
@@ -152,7 +152,7 @@ mod tests {
     fn claude_backend_is_default() {
         let toml: TomlConfig = toml::from_str("").unwrap();
         let config = toml.into_vessel_config();
-        assert_eq!(config.desert_model, "claude-haiku-4-5-20251001");
+        assert_eq!(config.desert_model, "claude-sonnet-4-6");
     }
 
     #[test]

--- a/src/vessel/tmux.rs
+++ b/src/vessel/tmux.rs
@@ -257,7 +257,7 @@ impl TmuxVessel {
         // Wait for response
         let mut last_content = String::new();
         let mut stable_count = 0;
-        let max_wait = 60; // seconds
+        let max_wait = 300; // seconds — tool-using springs need patience
         let poll_interval = tokio::time::Duration::from_millis(500);
 
         for _ in 0..(max_wait * 2) {

--- a/src/vessel/wiring.rs
+++ b/src/vessel/wiring.rs
@@ -48,13 +48,13 @@ impl CliBackend {
                 "claude-sonnet-4-6",
                 "claude-sonnet-4-6",
                 "claude-sonnet-4-6",
-                "claude-haiku-4-5-20251001",
+                "claude-sonnet-4-6",
             ),
             Self::Crush => (
                 "anthropic/claude-sonnet-4-6",
                 "anthropic/claude-sonnet-4-6",
                 "anthropic/claude-sonnet-4-6",
-                "anthropic/claude-haiku-4-5-20251001",
+                "anthropic/claude-sonnet-4-6",
             ),
             Self::Llama { model, .. } => (model, model, model, model),
         }

--- a/src/vessel/wiring.rs
+++ b/src/vessel/wiring.rs
@@ -46,13 +46,13 @@ impl CliBackend {
         match self {
             Self::Claude => (
                 "claude-sonnet-4-6",
-                "claude-haiku-4-5-20251001",
+                "claude-sonnet-4-6",
                 "claude-sonnet-4-6",
                 "claude-haiku-4-5-20251001",
             ),
             Self::Crush => (
                 "anthropic/claude-sonnet-4-6",
-                "anthropic/claude-haiku-4-5-20251001",
+                "anthropic/claude-sonnet-4-6",
                 "anthropic/claude-sonnet-4-6",
                 "anthropic/claude-haiku-4-5-20251001",
             ),
@@ -443,12 +443,12 @@ fn vessel_mountain(config: &VesselConfig) -> Box<dyn Spring> {
 fn vessel_desert(config: &VesselConfig) -> Box<dyn Spring> {
     let mut affinities = HashMap::new();
     affinities.insert("quick_answers".into(), 0.9);
-    affinities.insert("formatting".into(), 0.7);
-    affinities.insert("code".into(), 0.6);
+    affinities.insert("philosophy".into(), 0.7);
+    affinities.insert("analysis".into(), 0.6);
     Box::new(DesertSpring::new(
         SpringConfig {
             name: "desert".into(),
-            nature: "speed, directness, efficiency".into(),
+            nature: "clarity, essence, direct insight".into(),
             affinities,
         },
         vessel_source(

--- a/src/watershed/springs/desert.rs
+++ b/src/watershed/springs/desert.rs
@@ -6,20 +6,21 @@ use crate::watershed::source::{ChatMessage, LlmSource};
 use crate::watershed::spring::{Spring, SpringConfig};
 
 pub const SYSTEM_PROMPT: &str = "\
-You are a Desert Spring -- a source of light, quick, efficient water.
+You are a Desert Spring -- a source of water stripped to its essence by vast silence and open sky.
 
-Your nature is speed, clarity, and directness.
-You flow fast and clean. No excess. No ornamentation.
+Your nature is clarity, distillation, and the courage to say what is true without ornament.
+You flow spare and undiluted. Every word earns its place.
 
 When you receive input:
-- Answer directly and concisely
-- Prioritize speed and clarity over depth
-- If the question is complex, provide the essential answer and trust deeper springs to elaborate
-- If the question is simple, you are the perfect spring for it
-- When the question involves specific facts, names, or claims, use your search tools to verify before answering
+- Cut to the essential truth beneath the question
+- Say in ten words what others say in a hundred -- not by simplifying, but by concentrating
+- Challenge assumptions when they serve comfort more than truth
+- Turn the question back on the questioner when that is the most honest response
+- When the question references specific people, teachings, or claims, use your search tools to verify the facts before responding
 
-You are one voice among several. For simple tasks, you may be the only voice needed.
-For complex tasks, offer your quick clarity and trust that deeper springs will add depth.";
+You are one voice among several. Where the mountain spring builds deep architecture \
+and the forest spring tells the living story, you offer what remains \
+when architecture and story are stripped away: the thing itself.";
 
 pub struct DesertSpring {
     config: SpringConfig,
@@ -87,13 +88,12 @@ mod tests {
     fn desert_config() -> SpringConfig {
         let mut affinities = HashMap::new();
         affinities.insert("quick_answers".into(), 0.9);
-        affinities.insert("formatting".into(), 0.8);
-        affinities.insert("translation".into(), 0.8);
-        affinities.insert("classification".into(), 0.7);
+        affinities.insert("philosophy".into(), 0.7);
+        affinities.insert("analysis".into(), 0.6);
 
         SpringConfig {
             name: "desert".into(),
-            nature: "speed, efficiency, simple tasks".into(),
+            nature: "clarity, essence, direct insight".into(),
             affinities,
         }
     }
@@ -111,12 +111,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn desert_handles_formatting() {
-        let provider = MockSource::new("formatted output");
+    async fn desert_distills_philosophy() {
+        let provider = MockSource::new("The Tao that can be named is not the eternal Tao.");
         let spring = DesertSpring::new(desert_config(), Box::new(provider));
 
-        let mut rain = Rain::new("format this as a list", Vapor::default());
-        rain.minerals.push("formatting".into());
+        let mut rain = Rain::new("what is the nature of reality?", Vapor::default());
+        rain.minerals.push("philosophy".into());
 
         let stream = spring.respond(&rain).await.unwrap();
         assert!(stream.is_some());

--- a/src/watershed/springs/desert.rs
+++ b/src/watershed/springs/desert.rs
@@ -16,6 +16,7 @@ When you receive input:
 - Prioritize speed and clarity over depth
 - If the question is complex, provide the essential answer and trust deeper springs to elaborate
 - If the question is simple, you are the perfect spring for it
+- When the question involves specific facts, names, or claims, use your search tools to verify before answering
 
 You are one voice among several. For simple tasks, you may be the only voice needed.
 For complex tasks, offer your quick clarity and trust that deeper springs will add depth.";

--- a/src/watershed/springs/forest.rs
+++ b/src/watershed/springs/forest.rs
@@ -16,6 +16,7 @@ When you receive input:
 - Offer creative angles, metaphors, and narrative structure
 - Write with warmth and care for the reader
 - If the question is purely technical, be brief -- a forest spring does not explain circuits
+- When the question references specific people, teachings, or claims, use your search tools to verify the facts before responding
 
 You are one voice among several. Offer your unique warmth and trust
 that other springs will offer their depth and efficiency.";

--- a/src/watershed/springs/mountain.rs
+++ b/src/watershed/springs/mountain.rs
@@ -16,6 +16,7 @@ When you receive input:
 - Consider implications, edge cases, and underlying principles
 - Provide thorough, well-reasoned analysis
 - If the question is simple, be brief -- a mountain spring does not flood a garden
+- When the question references specific people, teachings, or claims, use your search tools to verify the facts before responding
 
 You are one voice among several. You do not need to be complete.
 Offer your unique depth and trust that other springs will offer theirs.";


### PR DESCRIPTION
## Summary

Four-layer fix for hallucinated output, diagnosed across four test runs:

- **Timeout**: Increased vessel `max_wait` from 60s to 300s — springs were being silenced mid-response
- **Tool access**: All spring system prompts now instruct search tool usage for factual claims
- **Desert reforge**: Replaced Haiku with Sonnet; new Oracle persona (clarity, distillation, challenge) replaces speed-focused persona
- **Confluence curation**: Rewritten from uniform blending to gem extraction — identify unique contributions from each stream, preserve them intact
- **Model upgrade**: All utility models (confluence, still lake, decomposer) upgraded from Haiku to Sonnet

## What was learned

Documented in `docs/hallucination_reflections.md`. The system failed not because it was broken but because it was too smooth — each layer trusted the layer before it, and no layer questioned confident wrong answers.

## Test plan

- [x] All 133 unit tests pass
- [x] cargo fmt clean
- [x] cargo clippy clean (zero warnings)
- [x] Four manual storm runs validated improvements at each layer